### PR TITLE
[STREAMPIPES-107] Fix link to JIRA

### DIFF
--- a/website/getinvolved.ejs
+++ b/website/getinvolved.ejs
@@ -20,7 +20,7 @@
                     <p>There are many ways to help. Become part of a highly motivated community and help growing
                         StreamPipes:</p>
                     <ul>
-                        <li><i class="fas fa-check sp-color-green"></i> Submit a bug report in our <a href="">JIRA</a></li>
+                        <li><i class="fas fa-check sp-color-green"></i> Submit a bug report in our <a href="https://issues.apache.org/jira/browse/STREAMPIPES">JIRA</a></li>
                         <li><i class="fas fa-check sp-color-green"></i> Subscribe to our <a href="/mailinglists.html">mailing lists</a></li>
                         <li><i class="fas fa-check sp-color-green"></i> Create a pull request on Github</li>
                     </ul>


### PR DESCRIPTION
Hi there,

This PR will fix link to JIRA in [get-involved page](https://streampipes.apache.org/getinvolved.html).

Fixes: https://issues.apache.org/jira/browse/STREAMPIPES-107

Regards,
Grainier

