### PR TITLE
Fix broken links on Streampipes documentation

### DIFF
--- a/documentation/docs/01_try-installation.md
+++ b/documentation/docs/01_try-installation.md
@@ -136,4 +136,4 @@ If there is a problem with any of the components, please restart the whole syste
 
 ## Next Steps
 
-That's it! To ease your first steps with StreamPipes, we've created an [interactive tutorial](try-tutorial).
+That's it! To ease your first steps with StreamPipes, we've created an [interactive tutorial](../try-tutorial).

--- a/documentation/docs/01_try-overview.md
+++ b/documentation/docs/01_try-overview.md
@@ -17,7 +17,7 @@ This is the documentation of Apache StreamPipes.
             </div>
             <div class="toc-content">
                 <div class="toc-section-header"><b>Your first steps with Apache StreamPipes.</b></div>
-               <a href="try-installation">Install StreamPipes</a>, <a href="try-tutorial">Interactive Tutorial</a>
+               <a href="../try-installation">Install StreamPipes</a>, <a href="../try-tutorial">Interactive Tutorial</a>
             </div>
         </div>
     </div>
@@ -28,7 +28,7 @@ This is the documentation of Apache StreamPipes.
             </div>
             <div class="toc-content">
                 <div class="toc-section-header"><b>Learn about some general concepts of StreamPipes.</b></div>
-                <a href="concepts-overview">Overview</a>
+                <a href="../concepts-overview">Overview</a>
             </div>
         </div>
     </div>
@@ -39,8 +39,10 @@ This is the documentation of Apache StreamPipes.
             </div>
             <div class="toc-content">
                 <div class="toc-section-header"><b>Learn how to use the various modules of StreamPipes.</b></div>
-                <a href="use-connect">StreamPipes Connect</a>, <a href="use-pipeline-editor">Pipeline Editor</a>, <a href="use-managing-pipelines">Managing Pipelines</a>, 
-                <a href="use-live-dashboard">Live Dashboard</a>, <a href="use-data-explorer">Data Explorer</a>, <a href="use-notifications">Notifications</a>
+                <a href="../use-connect">StreamPipes Connect</a>, <a href="../use-pipeline-editor">Pipeline Editor</a>, 
+                f="../use-managing-pipelines">Managing Pipelines</a>, 
+                <a href="../use-live-dashboard">Live Dashboard</a>, <a href="../use-data-explorer">Data Explorer</a>, 
+                f="../use-notifications">Notifications</a>
             </div>
         </div>
     </div>
@@ -51,9 +53,9 @@ This is the documentation of Apache StreamPipes.
             </div>
             <div class="toc-content">
                 <div class="toc-section-header"><b>Available pipeline elements in StreamPipes.</b></div>
-                <a href="pe/org.apache.streampipes.connect.protocol.stream.kafka">Adapters</a>, 
-                <a href="pe/org.apache.streampipes.processors.aggregation.flink.aggregation">Data Processors</a>, 
-                <a href="pe/org.apache.streampipes.sinks.databases.jvm.couchdb">Data Sinks</a> 
+                <a href="../pe/org.apache.streampipes.connect.protocol.stream.kafka">Adapters</a>, 
+                <a href="../pe/org.apache.streampipes.processors.aggregation.flink.aggregation">Data Processors</a>, 
+                <a href="../pe/org.apache.streampipes.sinks.databases.jvm.couchdb">Data Sinks</a> 
             </div>
         </div>
     </div>
@@ -64,7 +66,8 @@ This is the documentation of Apache StreamPipes.
             </div>
             <div class="toc-content">
                 <div class="toc-section-header"><b>How to set up StreamPipes in test and production environments.</b></div>
-                <a href="deploy-docker">Docker</a>, <a href="deploy-kubernetes">Kubernetes</a>, <a href="deploy-use-ssl">Use SSL</a>
+                <a href="../deploy-docker">Docker</a>, <a href="../deploy-kubernetes">Kubernetes</a>, <a href="../deploy
+                -use-ssl">Use SSL</a>
             </div>
         </div>
     </div>
@@ -75,10 +78,14 @@ This is the documentation of Apache StreamPipes.
             </div>
             <div class="toc-content">
                 <div class="toc-section-header"><b>Write your own pipeline elements for StreamPipes.</b></div>
-                <a href="extend-setup">Development Setup</a>, <a href="extend-cli">CLI</a>, <a href="extend-archetypes">Maven Archetypes</a>,
-                <a href="extend-tutorial-data-sources">Tutorial Data Sources</a>, <a href="extend-tutorial-data-processors">Tutorial Data Processors</a>, <a href="extend-tutorial-data-sinks">Tutorial Data Sinks</a>,
-                <a href="extend-sdk-event-model">Event Model</a>, <a href="extend-sdk-stream-requirements">Stream Requirements</a>, <a href="extend-sdk-static-properties">Static Properties</a>,
-                <a href="extend-output-strategies">Output Strategies</a>
+                <a href="../extend-setup">Development Setup</a>, <a href="../extend-cli">CLI</a>, <a href="../extend
+                -archetypes">Maven Archetypes</a>,
+                <a href="../extend-tutorial-data-sources">Tutorial Data Sources</a>, <a href="../extend-tutorial-data
+                -processors">Tutorial Data Processors</a>, <a href="../extend-tutorial-data-sinks">Tutorial Data Sinks
+                </a>,
+                <a href="../extend-sdk-event-model">Event Model</a>, <a href="../extend-sdk-stream-requirements">Stream
+                 Requirements</a>, <a href="../extend-sdk-static-properties">Static Properties</a>,
+                <a href="../extend-output-strategies">Output Strategies</a>
             </div>
         </div>
     </div>
@@ -89,8 +96,10 @@ This is the documentation of Apache StreamPipes.
             </div>
             <div class="toc-content">
                 <div class="toc-section-header"><b>Learn about technical concepts behind the curtain.</b></div>
-                <a href="technicals-architecture">Architecture</a>, <a href="technicals-user-guidance">User Guidance</a>, <a href="technicals-runtime-wrappers">Runtime Wrappers</a>,
-                <a href="technicals-messaging">Messaging</a>, <a href="technicals-configuration">Configuration</a>
+                <a href="../technicals-architecture">Architecture</a>, <a href="../technicals-user-guidance">User
+                 Guidance
+                </a>, <a href="technicals-runtime-wrappers">Runtime Wrappers</a>,
+                <a href="../technicals-messaging">Messaging</a>, <a href="../technicals-configuration">Configuration</a>
             </div>
         </div>
     </div>
@@ -101,7 +110,7 @@ This is the documentation of Apache StreamPipes.
             </div>
             <div class="toc-content">
                 <div class="toc-section-header"><b>Get support and learn how to contribute to StreamPipes.</b></div>
-                <a href="community-get-help">Get Help</a>, <a href="community-contribute">Contribute</a>
+                <a href="../community-get-help">Get Help</a>, <a href="../community-contribute">Contribute</a>
             </div>
         </div>
     </div>

--- a/documentation/docs/05_deploy-docker.md
+++ b/documentation/docs/05_deploy-docker.md
@@ -6,7 +6,8 @@ sidebar_label: Docker Deployment
 
 StreamPipes Compose is a simple collection of user-friendly `docker-compose` files that easily lets gain first-hand experience with Apache StreamPipes.
 
-> **NOTE**: We recommend StreamPipes Compose to only use for initial try-out and testing. If you are a developer and want to develop new pipeline elements or core feature, use the [StreamPipes CLI](../cli).
+> **NOTE**: We recommend StreamPipes Compose to only use for initial try-out and testing. If you are a developer and
+> want to develop new pipeline elements or core feature, use the [StreamPipes CLI](../extend-cli).
 
 #### TL;DR: A one-liner to rule them all :-)
 

--- a/documentation/docs/06_extend-sdk-output-strategies.md
+++ b/documentation/docs/06_extend-sdk-output-strategies.md
@@ -12,7 +12,9 @@ The following reference describes how output strategies can be defined using the
 
 <div class="admonition tip">
 <div class="admonition-title">Code on Github</div>
-<p>For all examples, the code can be found on <a href="https://www.github.com/apache/incubator-streampipes-examples/tree/dev/streampipes-pipeline-elements-examples-processors-jvm/src/main/java/org/streampipes/pe/examples/jvm/outputstrategy/">Github</a>.</p>
+<p>For all examples, the code can be found on <a href="https://www.github.com/apache/incubator-streampipes-examples
+/tree/dev/streampipes-pipeline-elements-examples-processors-jvm/src/main/java/org/apache/streampipes/pe/examples/jvm
+/outputstrategy/">Github</a>.</p>
 </div>
 
 ## Reference

--- a/documentation/docs/06_extend-sdk-static-properties.md
+++ b/documentation/docs/06_extend-sdk-static-properties.md
@@ -12,7 +12,9 @@ The following reference describes how static properties can be defined using the
 
 <div class="admonition tip">
 <div class="admonition-title">Code on Github</div>
-<p>For all examples, the code can be found on <a href="https://github.com/apache/incubator-streampipes-examples/tree/dev/streampipes-pipeline-elements-examples-processors-jvm/src/main/java/org/streampipes/pe/examples/jvm/staticproperty">Github</a>.</p>
+<p>For all examples, the code can be found on <a href="https://github.com/apache/incubator-streampipes-examples/tree
+/dev/streampipes-pipeline-elements-examples-processors-jvm/src/main/java/org/apache/streampipes/pe/examples/jvm
+/staticproperty">Github</a>.</p>
 </div>
 
 ## Reference

--- a/documentation/docs/06_extend-sdk-stream-requirements.md
+++ b/documentation/docs/06_extend-sdk-stream-requirements.md
@@ -14,7 +14,7 @@ This guide covers the creation of stream requirements. Before reading this secti
 
 <div class="admonition tip">
 <div class="admonition-title">Code on Github</div>
-<p>For all examples, the code can be found on <a href="https://www.github.com/apache/incubator-streampipes-examples/tree/dev/streampipes-pipeline-elements-examples-processors-jvm/src/main/java/org/streampipes/pe/examples/jvm/requirements/">Github</a>.</p>
+<p>For all examples, the code can be found on <a href="https://www.github.com/apache/incubator-streampipes-examples/tree/dev/streampipes-pipeline-elements-examples-processors-jvm/src/main/java/org/apache/streampipes/pe/examples/jvm/requirements/">Github</a>.</p>
 </div>
 
 ## The StreamRequirementsBuilder

--- a/documentation/docs/06_extend-setup.md
+++ b/documentation/docs/06_extend-setup.md
@@ -16,7 +16,7 @@ The only requirements in terms of development tools are that you have Java 8 and
 In order to quickly test developed pipeline elements without needing to install all services required by StreamPipes, we provide a CLI tool that allows you to selectively start StreamPipes components.
 The CLI tool allows to switch to several templates (based on docker-compose) depending on the role. 
 
-The documentation on the usage of the CLI tool is available [here](extend-cli).
+The documentation on the usage of the CLI tool is available [here](../extend-cli).
 ## Starter projects
 
 Now, once you've started the development instance, you are ready to develop your very first pipeline element.
@@ -24,7 +24,7 @@ Instead of starting from scratch, we recommend using our provided maven archetyp
 
 ### Maven archetypes
 
-Create the Maven archetype as described in the [Getting Started](extend-archetypes) guide.
+Create the Maven archetype as described in the [Getting Started](../extend-archetypes) guide.
 
 ### Examples
 

--- a/documentation/docs/06_extend-tutorial-data-processors.md
+++ b/documentation/docs/06_extend-tutorial-data-processors.md
@@ -156,7 +156,8 @@ In addition, we can assign a _value specification_ to the parameter indicating t
 Our example supports a radius value between 0 and 1000 with a granularity of 1.
 In the StreamPipes UI, a required text parameter is rendered as a text input field, in case we provide an optional value specification, a slider input is automatically generated.
 
-Such user-defined parameters are called _static properties_. There are many different types of static properties (see the [Processor SDK](dev-guide-sdk-guide-processors#docsNav) for an overview).
+Such user-defined parameters are called _static properties_. There are many different types of static properties (see
+ the [Processor SDK](../dev-guide-sdk-guide-processors#docsNav) for an overview).
 
 One example are _DomainProperties_ we use for defining the center of the geofence.
 Our data processor requires a lat/lng pair that marks the center of the geofence.
@@ -490,10 +491,11 @@ Click on the link of the data source to see the RDF description of the pipeline 
 <img src="/docs/img/tutorial-processors/pe-rdf-geofencing.PNG" alt="Geofencing RDF description">
 
 The container automatically registers itself in the Consul installation of StreamPipes.
-To install the just created element, open the StreamPipes UI and follow the manual provided in the [user guide](user-guide-installation).
+To install the just created element, open the StreamPipes UI and follow the manual provided in the [user guide](../user
+-guide-installation).
 
 ## Read more
 
 Congratulations! You've just created your first data processor for StreamPipes.
 There are many more things to explore and data processors can be defined in much more detail using multiple wrappers.
-Follow our [SDK guide](dev-guide-sdk-guide-processors) to see what's possible!
+Follow our [SDK guide](../dev-guide-sdk-guide-processors) to see what's possible!

--- a/documentation/docs/06_extend-tutorial-data-sinks.md
+++ b/documentation/docs/06_extend-tutorial-data-sinks.md
@@ -237,10 +237,11 @@ Now we are ready to start our container!
 Execute the main method in the class `Main` we've just created.
 
 The container automatically registers itself in the Consul installation of StreamPipes.
-To install the just created element, open the StreamPipes UI and follow the manual provided in the [user guide](user-guide-installation).
+To install the just created element, open the StreamPipes UI and follow the manual provided in the [user guide](../user
+-guide-installation).
 
 ## Read more
 
 Congratulations! You've just created your first data sink for StreamPipes.
 There are many more things to explore and data sinks can be defined in much more detail using multiple wrappers.
-Follow our [SDK guide](dev-guide-sdk-guide-sinks) to see what's possible!
+Follow our [SDK guide](../dev-guide-sdk-guide-sinks) to see what's possible!

--- a/documentation/docs/06_extend-tutorial-data-sources.md
+++ b/documentation/docs/06_extend-tutorial-data-sources.md
@@ -273,10 +273,11 @@ Click on the link of the data source to see the RDF description of the pipeline 
 <img src="/docs/img/tutorial-sources/pe-rdf.PNG" alt="Pipeline Element RDF description">
 
 The container automatically registers itself in the Consul installation of StreamPipes.
-To install the just created element, open the StreamPipes UI and follow the manual provided in the [user guide](user-guide-introduction).
+To install the just created element, open the StreamPipes UI and follow the manual provided in the [user guide](../user
+-guide-introduction).
 
 ## Read more
 
 Congratulations! You've just created your first pipeline element for StreamPipes.
 There are many more things to explore and data sources can be defined in much more detail.
-Follow our [SDK guide](dev-guide-source-sdk) to see what's possible!
+Follow our [SDK guide](../dev-guide-source-sdk) to see what's possible!

--- a/documentation/docs/dev-guide-processor-sdk.md
+++ b/documentation/docs/dev-guide-processor-sdk.md
@@ -5,7 +5,7 @@ sidebar_label: SDK Guide: Data Processors
 ---
 
 ## Project Setup
-(coming soon, please check the [tutorial](dev-guide-tutorial-processors) to learn how to define data processors)
+(coming soon, please check the [tutorial](../dev-guide-tutorial-processors) to learn how to define data processors)
 
 ## SDK reference
 The complete SDK reference for defining data processors will follow soon. Please check the SDK's Javadoc for now!

--- a/documentation/docs/dev-guide-sink-sdk.md
+++ b/documentation/docs/dev-guide-sink-sdk.md
@@ -5,7 +5,7 @@ sidebar_label: SDK Guide: Data Sinks
 ---
 
 ## Project Setup
-(coming soon, please check the [tutorial](dev-guide-tutorial-processors) to learn how to define sinks)
+(coming soon, please check the [tutorial](../dev-guide-tutorial-processors) to learn how to define sinks)
 
 ## SDK reference
 The complete SDK reference for defining data sinks will follow soon. Please check the SDK's Javadoc for now!

--- a/documentation/docs/pe/org.apache.streampipes.processors.filters.jvm.merge.md
+++ b/documentation/docs/pe/org.apache.streampipes.processors.filters.jvm.merge.md
@@ -33,13 +33,8 @@ sidebar_label: Merge By Time
 ## Description
 
 Merges two event streams by their timestamp.
-Two events of the different streams are merged when they occure to the same time
+Two events of the different streams are merged when they occur at the same time.
 
-The following figure shows how the events of the two data streams will be mergrged:
-
-<p align="center"> 
-    <img width="300px;" src="/docs/img/pipeline-elements/org.apache.streampipes.processors.filters.jvm.merge/merge_description.png" class="pe-image-documentation"/>
-</p>
 ***
 
 ## Required input
@@ -48,8 +43,8 @@ Each of the data streams needs a timestamp.
 
 ## Configuration
 
-* For each stream a the timestamp property on which the merger is performed has to be selected
+* For each stream the timestamp property on which the merger performed has to be selected
 * The Time Interval describes the maximum value between two events to decide whether they are a match. To be a valid match the following function must be true: | timestamp_stream_1 - timestamp_stream_2 | < interval
 
 ## Output
-The compose processor has a configurable output that can be selected by the user at pipeline modeling time.
+The merge processor has a configurable output that can be selected by the user at pipeline modeling time.


### PR DESCRIPTION
### Purpose
There are quite several broken links on Streampipes documentation. I have fixed some based on what I have identified. 

It would be better to run a dead-link validator against the documentation to fix all of them.


