### PR TITLE
Update groupId of streampipes-archetype-pe-sources

### DIFF
--- a/documentation/website/versioned_docs/version-0.67.0/06_extend-tutorial-data-sources.md
+++ b/documentation/website/versioned_docs/version-0.67.0/06_extend-tutorial-data-sources.md
@@ -32,7 +32,7 @@ Enter the following command in a command line of your choice (Apache Maven needs
 
 ```
 mvn archetype:generate \
--DarchetypeGroupId=org.streampipes -DarchetypeArtifactId=streampipes-archetype-pe-sources \
+-DarchetypeGroupId=org.apache.streampipes -DarchetypeArtifactId=streampipes-archetype-pe-sources \
 -DarchetypeVersion=0.67.0 -DgroupId=my.groupId \
 -DartifactId=my-source -DclassNamePrefix=MySource -DpackageName=mypackagename
 ```


### PR DESCRIPTION
### Purpose

Since version 0.66.0 the groupId of this archetype is org.apache.streampipes
### Approach

Update example